### PR TITLE
[CI] Added CI by using GitHub Actions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: build and test
+
+on: [push, pull_request]
+
+jobs:
+
+  job:
+
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+    - name: Git config
+      run: |
+        git config --global core.autocrlf false
+        git config --global core.eol lf
+
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+
+    - run: npm install
+
+    - run: npm run lint
+
+    - run: npm run build-production --if-present
+
+    - run: npm test
+      env:
+        CI: true

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![build and test](https://github.com/webmachinelearning/webnn-polyfill/workflows/build%20and%20test/badge.svg)](https://github.com/webmachinelearning/webnn-polyfill/actions)
+
 # WebNN Polyfill
 
 A JavaScript implementation of the [Web Neural Network API](https://webmachinelearning.github.io/webnn/).
@@ -22,14 +24,14 @@ A JavaScript implementation of the [Web Neural Network API](https://webmachinele
 
 #### Production build
 
-```
+```sh
 > npm run build-production
 ```
 
 ### Test
 #### Run tests in node.js.
 
-```hs
+```sh
 > npm test
 ```
 


### PR DESCRIPTION
This PR is to add CI by using [GitHub Actions](https://github.com/features/actions). This CI will help lint, build and test  in node.js with push commit or pull-request on Linux (Ubuntu 18.04) / Windows (Windows Server 2019) / macOS (macOS Catalina 10.15) virtual environments. And there's also a CI status badge on [README.md](https://github.com/webmachinelearning/webnn-polyfill/blob/master/README.md). @anssiko @huningxin PTAL, thanks. 


