### PR TITLE
Optimize the memory consumption for compute by disposing the intermediate tensors

### DIFF
--- a/src/nn/model.ts
+++ b/src/nn/model.ts
@@ -1,6 +1,6 @@
 import {Compilation} from './compilation';
 import {NamedOperands} from './model_builder';
-import {ConstantOperand, InputOperand, OutputOperand} from './operand';
+import {ConstantOperand, InputOperand, Operand, OutputOperand} from './operand';
 import {Operation} from './operation';
 import * as utils from './utils';
 
@@ -30,6 +30,7 @@ export class Model {
   private inputs_: Map<string, InputOperand> = new Map();
   private outputs_: Map<string, OutputOperand> = new Map();
   private constants_: Set<ConstantOperand> = new Set();
+  private operandRefs_: Map<Operand, number> = new Map();
 
   /** @ignore */
   get inputs(): Map<string, InputOperand> {
@@ -42,6 +43,10 @@ export class Model {
   /** @ignore */
   get constants(): ConstantOperand[] {
     return Array.from(this.constants_.values());
+  }
+  /** @ignore */
+  get operandRefs(): Map<Operand, number> {
+    return this.operandRefs_;
   }
 
   /** @ignore */
@@ -77,6 +82,13 @@ export class Model {
       visitedOps.add(operation);
     }
     for (const operand of operation.inputs()) {
+      if (!this.operandRefs_.has(operand)) {
+        this.operandRefs_.set(operand, 1);
+      } else {
+        let ref = this.operandRefs_.get(operand);
+        ref++;
+        this.operandRefs_.set(operand, ref);
+      }
       if (operand instanceof InputOperand) {
         if (this.inputs_.has(operand.name)) {
           if (this.inputs_.get(operand.name) !== operand) {

--- a/src/nn/ops/batch_norm.ts
+++ b/src/nn/ops/batch_norm.ts
@@ -1,6 +1,5 @@
 import * as tf from '@tensorflow/tfjs-core';
 
-import {ExecutionContext} from '../compilation';
 import {BatchNormalizationOptions} from '../model_builder';
 import {Operand} from '../operand';
 import {SingleOutputOperation} from '../operation';
@@ -57,24 +56,24 @@ export class BatchNormalization extends SingleOutputOperation {
     return inputs;
   }
 
-  run(context: ExecutionContext): tf.Tensor {
-    const input: tf.Tensor = context.getTensor(this.input_);
+  run(inputTensors: Map<Operand, tf.Tensor>): tf.Tensor {
+    const input: tf.Tensor = inputTensors.get(this.input_);
     utils.assert(
         this.axis_ < input.rank && this.axis_ >= -input.rank,
         'The axis parameter is invalid.');
     const axis = this.axis_ >= 0 ? this.axis_ : input.rank + this.axis_;
-    const mean: tf.Tensor = context.getTensor(this.mean_);
+    const mean: tf.Tensor = inputTensors.get(this.mean_);
     utils.assert(mean.rank === 1, 'The mean operand is not 1-D.');
-    const variance: tf.Tensor = context.getTensor(this.variance_);
+    const variance: tf.Tensor = inputTensors.get(this.variance_);
     utils.assert(variance.rank === 1, 'The mean operand is not 1-D.');
     let scale: tf.Tensor;
     if (this.scale_) {
-      scale = context.getTensor(this.scale_);
+      scale = inputTensors.get(this.scale_);
       utils.assert(scale.rank === 1, 'The scale operand is not 1-D.');
     }
     let bias: tf.Tensor;
     if (this.bias_) {
-      bias = context.getTensor(this.bias_);
+      bias = inputTensors.get(this.bias_);
       utils.assert(bias.rank === 1, 'The bias operand is not 1-D.');
     }
     // tf.batchNorm only computes for the last dimension.

--- a/src/nn/ops/binary.ts
+++ b/src/nn/ops/binary.ts
@@ -1,6 +1,5 @@
 import * as tf from '@tensorflow/tfjs-core';
 
-import {ExecutionContext} from '../compilation';
 import {Operand} from '../operand';
 import {SingleOutputOperation} from '../operation';
 import * as utils from '../utils';
@@ -21,9 +20,9 @@ export abstract class Binary extends SingleOutputOperation {
     return [this.a_, this.b_];
   }
 
-  run(context: ExecutionContext): tf.Tensor {
-    const a: tf.Tensor = context.getTensor(this.a_);
-    const b: tf.Tensor = context.getTensor(this.b_);
+  run(inputTensors: Map<Operand, tf.Tensor>): tf.Tensor {
+    const a: tf.Tensor = inputTensors.get(this.a_);
+    const b: tf.Tensor = inputTensors.get(this.b_);
     return this.runOp(a, b);
   }
 

--- a/src/nn/ops/clamp.ts
+++ b/src/nn/ops/clamp.ts
@@ -1,6 +1,5 @@
 import * as tf from '@tensorflow/tfjs-core';
 
-import {ExecutionContext} from '../compilation';
 import {ClampOptions} from '../model_builder';
 import {Operand} from '../operand';
 import {SingleOutputOperation} from '../operation';
@@ -32,21 +31,21 @@ export class Clamp extends SingleOutputOperation {
     return inputs;
   }
 
-  run(context: ExecutionContext): tf.Tensor {
-    const x: tf.Tensor = context.getTensor(this.x_);
+  run(inputTensors: Map<Operand, tf.Tensor>): tf.Tensor {
+    const x: tf.Tensor = inputTensors.get(this.x_);
     if (this.minValue_) {
       if (this.maxValue_) {
         return tf.minimum(
-            tf.maximum(x, context.getTensor(this.minValue_)),
-            context.getTensor(this.maxValue_));
+            tf.maximum(x, inputTensors.get(this.minValue_)),
+            inputTensors.get(this.maxValue_));
       } else {
-        return tf.maximum(x, context.getTensor(this.minValue_));
+        return tf.maximum(x, inputTensors.get(this.minValue_));
       }
     } else {
       if (this.maxValue_) {
-        return tf.minimum(x, context.getTensor(this.maxValue_));
+        return tf.minimum(x, inputTensors.get(this.maxValue_));
       } else {
-        return x;
+        return tf.clone(x);
       }
     }
   }

--- a/src/nn/ops/concat.ts
+++ b/src/nn/ops/concat.ts
@@ -1,6 +1,5 @@
 import * as tf from '@tensorflow/tfjs-core';
 
-import {ExecutionContext} from '../compilation';
 import {Operand} from '../operand';
 import {SingleOutputOperation} from '../operation';
 import * as utils from '../utils';
@@ -23,10 +22,10 @@ export class Concat extends SingleOutputOperation {
     return this.inputs_;
   }
 
-  run(context: ExecutionContext): tf.Tensor {
+  run(inputTensors: Map<Operand, tf.Tensor>): tf.Tensor {
     const inputs: tf.Tensor[] = [];
     for (const input of this.inputs()) {
-      inputs.push(context.getTensor(input));
+      inputs.push(inputTensors.get(input));
     }
     return tf.concat(inputs, this.axis_);
   }

--- a/src/nn/ops/conv2d.ts
+++ b/src/nn/ops/conv2d.ts
@@ -1,7 +1,6 @@
 import * as tf from '@tensorflow/tfjs-core';
 import {ExplicitPadding} from '@tensorflow/tfjs-core/src/ops/conv_util';
 
-import {ExecutionContext} from '../compilation';
 import {AutoPad, Conv2dOptions, FilterOperandLayout, InputOperandLayout} from '../model_builder';
 import {Operand} from '../operand';
 import {SingleOutputOperation} from '../operation';
@@ -95,9 +94,9 @@ export class Conv2d extends SingleOutputOperation {
     return [this.input_, this.filter_];
   }
 
-  run(context: ExecutionContext): tf.Tensor {
-    let input: tf.Tensor4D = context.getTensor(this.input_) as tf.Tensor4D;
-    let filter: tf.Tensor4D = context.getTensor(this.filter_) as tf.Tensor4D;
+  run(inputTensors: Map<Operand, tf.Tensor>): tf.Tensor {
+    let input: tf.Tensor4D = inputTensors.get(this.input_) as tf.Tensor4D;
+    let filter: tf.Tensor4D = inputTensors.get(this.filter_) as tf.Tensor4D;
 
     // tf.conv2d input layout (nhwc): [batch, height, width, inDepth]
     if (this.inputLayout_ === InputOperandLayout.nchw) {

--- a/src/nn/ops/instance_norm.ts
+++ b/src/nn/ops/instance_norm.ts
@@ -1,6 +1,5 @@
 import * as tf from '@tensorflow/tfjs-core';
 
-import {ExecutionContext} from '../compilation';
 import {InputOperandLayout, InstanceNormalizationOptions} from '../model_builder';
 import {Operand} from '../operand';
 import {SingleOutputOperation} from '../operation';
@@ -50,8 +49,8 @@ export class InstanceNormalization extends SingleOutputOperation {
     return inputs;
   }
 
-  run(context: ExecutionContext): tf.Tensor {
-    const input: tf.Tensor = context.getTensor(this.input_);
+  run(inputTensors: Map<Operand, tf.Tensor>): tf.Tensor {
+    const input: tf.Tensor = inputTensors.get(this.input_);
     utils.assert(input.rank === 4, 'The input operand is not 4-D.');
     let axes = [2, 3];
     let shape = [1, -1, 1, 1];
@@ -63,7 +62,7 @@ export class InstanceNormalization extends SingleOutputOperation {
     }
     let scale: tf.Tensor;
     if (this.scale_) {
-      scale = context.getTensor(this.scale_);
+      scale = inputTensors.get(this.scale_);
       utils.assert(scale.rank === 1, 'The scale operand is not 1-D.');
       utils.assert(
           scale.shape[0] === inputChannels,
@@ -73,7 +72,7 @@ export class InstanceNormalization extends SingleOutputOperation {
     }
     let bias: tf.Tensor;
     if (this.bias_) {
-      bias = context.getTensor(this.bias_);
+      bias = inputTensors.get(this.bias_);
       utils.assert(bias.rank === 1, 'The bias operand is not 1-D.');
       utils.assert(
           bias.shape[0] === inputChannels,

--- a/src/nn/ops/leaky_relu.ts
+++ b/src/nn/ops/leaky_relu.ts
@@ -1,6 +1,5 @@
 import * as tf from '@tensorflow/tfjs-core';
 
-import {ExecutionContext} from '../compilation';
 import {Operand} from '../operand';
 import {SingleOutputOperation} from '../operation';
 import * as utils from '../utils';
@@ -21,8 +20,8 @@ export class LeakyRelu extends SingleOutputOperation {
     return [this.x_];
   }
 
-  run(context: ExecutionContext): tf.Tensor {
-    const x: tf.Tensor = context.getTensor(this.x_);
+  run(inputTensors: Map<Operand, tf.Tensor>): tf.Tensor {
+    const x: tf.Tensor = inputTensors.get(this.x_);
     return tf.leakyRelu(x, this.alpha_);
   }
 }

--- a/src/nn/ops/pad.ts
+++ b/src/nn/ops/pad.ts
@@ -1,6 +1,5 @@
 import * as tf from '@tensorflow/tfjs-core';
 
-import {ExecutionContext} from '../compilation';
 import {PaddingMode, PadOptions} from '../model_builder';
 import {Operand} from '../operand';
 import {SingleOutputOperation} from '../operation';
@@ -32,9 +31,9 @@ export class Pad extends SingleOutputOperation {
     return [this.input_, this.padding_];
   }
 
-  run(context: ExecutionContext): tf.Tensor {
-    const input: tf.Tensor = context.getTensor(this.input_);
-    const padding: tf.Tensor = context.getTensor(this.padding_);
+  run(inputTensors: Map<Operand, tf.Tensor>): tf.Tensor {
+    const input: tf.Tensor = inputTensors.get(this.input_);
+    const padding: tf.Tensor = inputTensors.get(this.padding_);
     utils.assert(
         padding.rank === 2 && padding.dtype === 'int32' &&
             padding.shape[0] === input.rank,

--- a/src/nn/ops/pool2d.ts
+++ b/src/nn/ops/pool2d.ts
@@ -1,6 +1,5 @@
 import * as tf from '@tensorflow/tfjs-core';
 
-import {ExecutionContext} from '../compilation';
 import {AutoPad, InputOperandLayout, Pooling2dOptions} from '../model_builder';
 import {Operand} from '../operand';
 import {SingleOutputOperation} from '../operation';
@@ -65,8 +64,8 @@ export abstract class Pool extends SingleOutputOperation {
     return [this.input_];
   }
 
-  run(context: ExecutionContext): tf.Tensor {
-    let input: tf.Tensor4D = context.getTensor(this.input_) as tf.Tensor4D;
+  run(inputTensors: Map<Operand, tf.Tensor>): tf.Tensor {
+    let input: tf.Tensor4D = inputTensors.get(this.input_) as tf.Tensor4D;
     let padding: 'valid'|'same'|number;
     if (this.autoPad_ === AutoPad.explicit) {
       utils.assert(

--- a/src/nn/ops/reduce.ts
+++ b/src/nn/ops/reduce.ts
@@ -1,6 +1,5 @@
 import * as tf from '@tensorflow/tfjs-core';
 
-import {ExecutionContext} from '../compilation';
 import {ReduceOptions} from '../model_builder';
 import {Operand} from '../operand';
 import {SingleOutputOperation} from '../operation';
@@ -38,8 +37,8 @@ abstract class Reduce extends SingleOutputOperation {
     return [this.input_];
   }
 
-  run(context: ExecutionContext): tf.Tensor {
-    const input: tf.Tensor = context.getTensor(this.input_);
+  run(inputTensors: Map<Operand, tf.Tensor>): tf.Tensor {
+    const input: tf.Tensor = inputTensors.get(this.input_);
     // tf.mean accepts axis range [-r, r)
     return this.runOp(input, this.axes_, this.keepDimensions_);
   }

--- a/src/nn/ops/resample.ts
+++ b/src/nn/ops/resample.ts
@@ -1,6 +1,5 @@
 import * as tf from '@tensorflow/tfjs-core';
 
-import {ExecutionContext} from '../compilation';
 import {InterpolationMode, ResampleOptions} from '../model_builder';
 import {Operand} from '../operand';
 import {SingleOutputOperation} from '../operation';
@@ -45,8 +44,8 @@ export class Resample extends SingleOutputOperation {
     return [this.input_];
   }
 
-  run(context: ExecutionContext): tf.Tensor {
-    let input: tf.Tensor4D = context.getTensor(this.input_) as tf.Tensor4D;
+  run(inputTensors: Map<Operand, tf.Tensor>): tf.Tensor {
+    let input: tf.Tensor4D = inputTensors.get(this.input_) as tf.Tensor4D;
     utils.assert(input.rank === 4, 'The input tensor is not 4-D.');
     const sizes: [number, number] = [0, 0];
     let transposed = false;

--- a/src/nn/ops/reshape.ts
+++ b/src/nn/ops/reshape.ts
@@ -1,6 +1,5 @@
 import * as tf from '@tensorflow/tfjs-core';
 
-import {ExecutionContext} from '../compilation';
 import {Operand} from '../operand';
 import {SingleOutputOperation} from '../operation';
 import * as utils from '../utils';
@@ -23,8 +22,8 @@ export class Reshape extends SingleOutputOperation {
     return [this.input_];
   }
 
-  run(context: ExecutionContext): tf.Tensor {
-    const input: tf.Tensor = context.getTensor(this.input_);
+  run(inputTensors: Map<Operand, tf.Tensor>): tf.Tensor {
+    const input: tf.Tensor = inputTensors.get(this.input_);
     return tf.reshape(input, this.newShape_);
   }
 }

--- a/src/nn/ops/slice.ts
+++ b/src/nn/ops/slice.ts
@@ -1,6 +1,5 @@
 import * as tf from '@tensorflow/tfjs-core';
 
-import {ExecutionContext} from '../compilation';
 import {Operand} from '../operand';
 import {SingleOutputOperation} from '../operation';
 import * as utils from '../utils';
@@ -40,8 +39,8 @@ export class Slice extends SingleOutputOperation {
     return [this.input_];
   }
 
-  run(context: ExecutionContext): tf.Tensor {
-    const input: tf.Tensor4D = context.getTensor(this.input_) as tf.Tensor4D;
+  run(inputTensors: Map<Operand, tf.Tensor>): tf.Tensor {
+    const input: tf.Tensor4D = inputTensors.get(this.input_) as tf.Tensor4D;
     const rank = input.shape.length;
     if (this.axes_ === undefined) {
       // assume axes is [0, 1,...r-1] if it is not defined.

--- a/src/nn/ops/softmax.ts
+++ b/src/nn/ops/softmax.ts
@@ -1,6 +1,5 @@
 import * as tf from '@tensorflow/tfjs-core';
 
-import {ExecutionContext} from '../compilation';
 import {Operand} from '../operand';
 import {SingleOutputOperation} from '../operation';
 import * as utils from '../utils';
@@ -18,8 +17,8 @@ export class Softmax extends SingleOutputOperation {
     return [this.x_];
   }
 
-  run(context: ExecutionContext): tf.Tensor {
-    const x: tf.Tensor = context.getTensor(this.x_);
+  run(inputTensors: Map<Operand, tf.Tensor>): tf.Tensor {
+    const x: tf.Tensor = inputTensors.get(this.x_);
     if (x.rank !== 2) {
       throw new Error('The rank of x parameter should be 2.');
     }

--- a/src/nn/ops/split.ts
+++ b/src/nn/ops/split.ts
@@ -1,6 +1,5 @@
 import * as tf from '@tensorflow/tfjs-core';
 
-import {ExecutionContext} from '../compilation';
 import {SplitOptions} from '../model_builder';
 import {Operand, OutputOperand} from '../operand';
 import {Operation} from '../operation';
@@ -37,11 +36,8 @@ export class Split extends Operation {
     return [this.input_];
   }
 
-  compute(context: ExecutionContext): void {
-    const input: tf.Tensor = context.getTensor(this.input_);
-    const tensors = tf.split(input, this.splits_, this.axis_);
-    for (let i = 0; i < tensors.length; ++i) {
-      context.setOutputTensor(this.outputs[i], tensors[i]);
-    }
+  computeImpl(inputTensors: Map<Operand, tf.Tensor>): tf.Tensor[] {
+    const input: tf.Tensor = inputTensors.get(this.input_);
+    return tf.split(input, this.splits_, this.axis_);
   }
 }

--- a/src/nn/ops/squeeze.ts
+++ b/src/nn/ops/squeeze.ts
@@ -1,6 +1,5 @@
 import * as tf from '@tensorflow/tfjs-core';
 
-import {ExecutionContext} from '../compilation';
 import {Operand} from '../operand';
 import {SingleOutputOperation} from '../operation';
 import * as utils from '../utils';
@@ -25,8 +24,8 @@ export class Squeeze extends SingleOutputOperation {
     return [this.input_];
   }
 
-  run(context: ExecutionContext): tf.Tensor {
-    const input: tf.Tensor = context.getTensor(this.input_);
+  run(inputTensors: Map<Operand, tf.Tensor>): tf.Tensor {
+    const input: tf.Tensor = inputTensors.get(this.input_);
     return tf.squeeze(input, this.axes_);
   }
 }

--- a/src/nn/ops/transpose.ts
+++ b/src/nn/ops/transpose.ts
@@ -1,6 +1,5 @@
 import * as tf from '@tensorflow/tfjs-core';
 
-import {ExecutionContext} from '../compilation';
 import {Operand} from '../operand';
 import {SingleOutputOperation} from '../operation';
 import * as utils from '../utils';
@@ -25,8 +24,8 @@ export class Transpose extends SingleOutputOperation {
     return [this.input_];
   }
 
-  run(context: ExecutionContext): tf.Tensor {
-    const input: tf.Tensor = context.getTensor(this.input_);
+  run(inputTensors: Map<Operand, tf.Tensor>): tf.Tensor {
+    const input: tf.Tensor = inputTensors.get(this.input_);
     return tf.transpose(input, this.permutation_);
   }
 }

--- a/src/nn/ops/unary.ts
+++ b/src/nn/ops/unary.ts
@@ -1,6 +1,5 @@
 import * as tf from '@tensorflow/tfjs-core';
 
-import {ExecutionContext} from '../compilation';
 import {Operand} from '../operand';
 import {SingleOutputOperation} from '../operation';
 import * as utils from '../utils';
@@ -18,8 +17,8 @@ export abstract class Unary extends SingleOutputOperation {
     return [this.x_];
   }
 
-  run(context: ExecutionContext): tf.Tensor {
-    const x: tf.Tensor = context.getTensor(this.x_);
+  run(inputTensors: Map<Operand, tf.Tensor>): tf.Tensor {
+    const x: tf.Tensor = inputTensors.get(this.x_);
     return this.runOp(x);
   }
 

--- a/test/api/compilation.js
+++ b/test/api/compilation.js
@@ -317,6 +317,7 @@ describe('test Compilation', function() {
   it('Compilation should not leak memory', async () => {
     // Only run this test for polyfill.
     if (typeof _tfengine !== 'undefined') {
+      const beforeNumBytes = _tfengine.memory().numBytes;
       const beforeNumTensors = _tfengine.memory().numTensors;
 
       // Run gru modele which is a complex graph
@@ -388,9 +389,13 @@ describe('test Compilation', function() {
       // Check memory leaks.
       compiledModel.dispose();
       const afterNumTensors = _tfengine.memory().numTensors;
+      const afterNumBytes = _tfengine.memory().numBytes;
       assert(
           beforeNumTensors === afterNumTensors,
           `${afterNumTensors - beforeNumTensors} tensors are leaked.`);
+      assert(
+          beforeNumBytes === afterNumBytes,
+          `${afterNumBytes - beforeNumBytes} bytes are leaked.`);
     }
   });
 });

--- a/test/models/squeezenet1.0_nhwc/squeezenet.js
+++ b/test/models/squeezenet1.0_nhwc/squeezenet.js
@@ -2,12 +2,19 @@
 import * as utils from '../../utils.js';
 
 const url = import.meta.url;
+const assert = chai.assert;
 
 describe('test squeezenet1.0 nhwc', function() {
   // eslint-disable-next-line no-invalid-this
   this.timeout(0);
   let compiledModel;
+  let beforeNumBytes;
+  let beforeNumTensors;
   before(async () => {
+    if (typeof _tfengine !== 'undefined') {
+      beforeNumBytes = _tfengine.memory().numBytes;
+      beforeNumTensors = _tfengine.memory().numTensors;
+    }
     const nn = navigator.ml.getNeuralNetworkContext();
     const builder = nn.createModelBuilder();
 
@@ -69,6 +76,21 @@ describe('test squeezenet1.0 nhwc', function() {
     const softmax = builder.softmax(reshape);
     const model = builder.createModel({softmax});
     compiledModel = await model.compile();
+  });
+
+  after(async () => {
+    if (typeof _tfengine !== 'undefined') {
+      // Check memory leaks.
+      compiledModel.dispose();
+      const afterNumTensors = _tfengine.memory().numTensors;
+      const afterNumBytes = _tfengine.memory().numBytes;
+      assert(
+          beforeNumTensors === afterNumTensors,
+          `${afterNumTensors - beforeNumTensors} tensors are leaked.`);
+      assert(
+          beforeNumBytes === afterNumBytes,
+          `${afterNumBytes - beforeNumBytes} bytes are leaked.`);
+    }
   });
 
   async function testSqueezeNet(inputFile, expectedFile) {


### PR DESCRIPTION
This PR would help the model execution. For example the squeezenet test, log the memory info by `tf.memory()` before and after applying this PR:

before
```
max numBytes 73376576 numTensors 256
```

after
```
max numBytes 9813028 numTensors 55
```

201 tensors and 60MB memory are reduced for squeezenet compute.

cc @Honry, this would also help the style transfer sample development.