### PR TITLE
Fixed 'same-upper' autoPad issues of conv2d and pool2d ops.

### DIFF
--- a/src/nn/ops/conv2d.ts
+++ b/src/nn/ops/conv2d.ts
@@ -133,8 +133,8 @@ export class Conv2d extends SingleOutputOperation {
             ] as ExplicitPadding;
           }
         } else {
-          // Calculate the explicit paddings for 'same-upper'
-          if (this.autoPad_ === MLAutoPad['same-upper']) {
+          // Calculate the explicit paddings for 'same-lower'
+          if (this.autoPad_ === MLAutoPad['same-lower']) {
             padding = [[0, 0], [0, 0], [0, 0], [0, 0]];
             const outputSizes = [0, 0];
             for (let i = 0; i < 2; ++i) {
@@ -153,7 +153,7 @@ export class Conv2d extends SingleOutputOperation {
               padding[i + 1][1] = Math.floor(totalPadding[i] / 2);
             }
           } else {
-            // 'same-lower'
+            // 'same-upper'
             padding = 'same';
           }
         }
@@ -168,11 +168,11 @@ export class Conv2d extends SingleOutputOperation {
               'tf.depthwiseConv2d only supports the same padding value.');
           padding = this.padding_[0] === 0 ? 'valid' : this.padding_[0];
         } else {
-          if (this.autoPad_ === MLAutoPad['same-lower']) {
+          if (this.autoPad_ === MLAutoPad['same-upper']) {
             padding = 'same';
           } else {
             throw new Error(
-                'tf.depthwiseConv2d only supports the same-lower auto pad.');
+                'tf.depthwiseConv2d only supports the same-upper auto pad.');
           }
         }
         // filter layout hwio
@@ -198,7 +198,7 @@ export class Conv2d extends SingleOutputOperation {
             'tf.conv2dTranspose only supports the same padding value.');
         padding = this.padding_[0] === 0 ? 'valid' : this.padding_[0];
       } else {
-        if (this.autoPad_ === MLAutoPad['same-lower']) {
+        if (this.autoPad_ === MLAutoPad['same-upper']) {
           padding = 'same';
           this.outputSizes_ = [
             input.shape[1] * this.strides_[0],
@@ -206,7 +206,7 @@ export class Conv2d extends SingleOutputOperation {
           ];
         } else {
           throw new Error(
-              'tf.conv2dTranspose only supports the same-lower auto pad.');
+              'tf.conv2dTranspose only supports the same-upper auto pad.');
         }
       }
       // tf.conv2dTranspose outputShape: [batch, height, width, outDepth]

--- a/src/nn/ops/pool2d.ts
+++ b/src/nn/ops/pool2d.ts
@@ -73,10 +73,10 @@ export abstract class Pool extends SingleOutputOperation {
           'tf.pool only supports the same padding value.');
       padding = this.padding_[0] === 0 ? 'valid' : this.padding_[0];
     } else {
-      if (this.autoPad_ === MLAutoPad['same-lower']) {
+      if (this.autoPad_ === MLAutoPad['same-upper']) {
         padding = 'same';
       } else {
-        throw new Error('tf.pool only supports the same-lower auto pad.');
+        throw new Error('tf.pool only supports the same-upper auto pad.');
       }
     }
     const poolingType = this.getPoolingType();

--- a/test/ops/conv2d.js
+++ b/test/ops/conv2d.js
@@ -863,7 +863,7 @@ describe('test conv2d', function() {
       data: [12., 27., 24., 63., 108., 81., 72., 117., 84.],
     };
     const options = {
-      autoPad: 'same-lower',
+      autoPad: 'same-upper',
       strides: [2, 2],
     };
     await testConv2d(input, filter, expected, options);
@@ -886,7 +886,7 @@ describe('test conv2d', function() {
       data: [12., 27., 24., 63., 108., 81., 72., 117., 84.],
     };
     const options = {
-      autoPad: 'same-lower',
+      autoPad: 'same-upper',
       strides: [2, 2],
       inputLayout: 'nchw',
       filterLayout: 'hwio',
@@ -911,7 +911,7 @@ describe('test conv2d', function() {
       data: [12., 27., 24., 63., 108., 81., 72., 117., 84.],
     };
     const options = {
-      autoPad: 'same-lower',
+      autoPad: 'same-upper',
       strides: [2, 2],
       inputLayout: 'nchw',
       filterLayout: 'ohwi',
@@ -936,7 +936,7 @@ describe('test conv2d', function() {
       data: [12., 27., 24., 63., 108., 81., 72., 117., 84.],
     };
     const options = {
-      autoPad: 'same-lower',
+      autoPad: 'same-upper',
       strides: [2, 2],
       inputLayout: 'nchw',
       filterLayout: 'ihwo',
@@ -961,7 +961,7 @@ describe('test conv2d', function() {
       data: [12., 27., 24., 63., 108., 81., 72., 117., 84.],
     };
     const options = {
-      autoPad: 'same-lower',
+      autoPad: 'same-upper',
       strides: [2, 2],
       inputLayout: 'nhwc',
       filterLayout: 'oihw',
@@ -986,7 +986,7 @@ describe('test conv2d', function() {
       data: [12., 27., 24., 63., 108., 81., 72., 117., 84.],
     };
     const options = {
-      autoPad: 'same-lower',
+      autoPad: 'same-upper',
       strides: [2, 2],
       inputLayout: 'nhwc',
       filterLayout: 'hwio',
@@ -1011,7 +1011,7 @@ describe('test conv2d', function() {
       data: [12., 27., 24., 63., 108., 81., 72., 117., 84.],
     };
     const options = {
-      autoPad: 'same-lower',
+      autoPad: 'same-upper',
       strides: [2, 2],
       inputLayout: 'nhwc',
       filterLayout: 'ohwi',
@@ -1036,7 +1036,7 @@ describe('test conv2d', function() {
       data: [12., 27., 24., 63., 108., 81., 72., 117., 84.],
     };
     const options = {
-      autoPad: 'same-lower',
+      autoPad: 'same-upper',
       strides: [2, 2],
       inputLayout: 'nhwc',
       filterLayout: 'ihwo',
@@ -2052,7 +2052,7 @@ describe('test conv2d', function() {
       ],
     };
     const options = {
-      autoPad: 'same-lower',
+      autoPad: 'same-upper',
       strides: [2, 2],
       transpose: true,
     };
@@ -2079,7 +2079,7 @@ describe('test conv2d', function() {
       ],
     };
     const options = {
-      autoPad: 'same-lower',
+      autoPad: 'same-upper',
       strides: [2, 2],
       transpose: true,
       inputLayout: 'nchw',
@@ -2108,7 +2108,7 @@ describe('test conv2d', function() {
       ],
     };
     const options = {
-      autoPad: 'same-lower',
+      autoPad: 'same-upper',
       strides: [2, 2],
       transpose: true,
       inputLayout: 'nchw',
@@ -2137,7 +2137,7 @@ describe('test conv2d', function() {
       ],
     };
     const options = {
-      autoPad: 'same-lower',
+      autoPad: 'same-upper',
       strides: [2, 2],
       transpose: true,
       inputLayout: 'nchw',
@@ -2166,7 +2166,7 @@ describe('test conv2d', function() {
       ],
     };
     const options = {
-      autoPad: 'same-lower',
+      autoPad: 'same-upper',
       strides: [2, 2],
       transpose: true,
       inputLayout: 'nhwc',
@@ -2195,7 +2195,7 @@ describe('test conv2d', function() {
       ],
     };
     const options = {
-      autoPad: 'same-lower',
+      autoPad: 'same-upper',
       strides: [2, 2],
       transpose: true,
       inputLayout: 'nhwc',
@@ -2224,7 +2224,7 @@ describe('test conv2d', function() {
       ],
     };
     const options = {
-      autoPad: 'same-lower',
+      autoPad: 'same-upper',
       strides: [2, 2],
       transpose: true,
       inputLayout: 'nhwc',
@@ -2253,7 +2253,7 @@ describe('test conv2d', function() {
       ],
     };
     const options = {
-      autoPad: 'same-lower',
+      autoPad: 'same-upper',
       strides: [2, 2],
       transpose: true,
       inputLayout: 'nhwc',

--- a/test/ops/pool2d.js
+++ b/test/ops/pool2d.js
@@ -69,7 +69,7 @@ describe('test pool2d', function() {
     const builder = new MLGraphBuilder(context);
     const x = builder.input('x', {type: 'float32', dimensions: [1, 1, 5, 5]});
     const windowDimensions = [5, 5];
-    const autoPad = 'same-lower';
+    const autoPad = 'same-upper';
     const y = builder.maxPool2d(x, {windowDimensions, autoPad});
     const graph = await builder.build({y});
     const inputs = {
@@ -156,7 +156,7 @@ describe('test pool2d', function() {
     const builder = new MLGraphBuilder(context);
     const x = builder.input('x', {type: 'float32', dimensions: [1, 1, 5, 5]});
     const windowDimensions = [5, 5];
-    const autoPad = 'same-lower';
+    const autoPad = 'same-upper';
     const y = builder.averagePool2d(x, {windowDimensions, autoPad});
     const graph = await builder.build({y});
     const inputs = {


### PR DESCRIPTION
This pr is to fix #57, also updated 16 conv2d and 2 pool2d tests with autoPad option.

@huningxin PTAL, thanks.