### PR TITLE
Updated criteria for model tests.

### DIFF
--- a/test/models/mobilenetv2_batchnorm_nchw.js
+++ b/test/models/mobilenetv2_batchnorm_nchw.js
@@ -132,10 +132,10 @@ describe('test mobilenetv2 batchnorm nchw', function() {
     const expected =
         await utils.createTypedArrayFromNpy(new URL(expectedFile, url));
     utils.checkValue(
-        outputs.reshape0, expected, new utils.AccuracyCriterion(1e-5, 1e-3));
+        outputs.reshape0, expected, utils.modelFp32AccuracyCriteria);
   }
 
-  it.skip('test_data_set_0', async function() {
+  it('test_data_set_0', async function() {
     await testMobileNetV2(
         `${testDataDir}/test_data_set/0/input_0.npy`,
         `${testDataDir}/test_data_set/0/output_0.npy`);

--- a/test/models/mobilenetv2_nchw.js
+++ b/test/models/mobilenetv2_nchw.js
@@ -143,7 +143,7 @@ describe('test mobilenetv2 nchw', function() {
     const expected =
         await utils.createTypedArrayFromNpy(new URL(expectedFile, url));
     utils.checkValue(
-        outputs.gemm, expected, new utils.AccuracyCriterion(1e-5, 1e-3));
+        outputs.gemm, expected, utils.modelFp32AccuracyCriteria);
   }
 
   it('test_data_set_0', async function() {

--- a/test/models/mobilenetv2_nhwc.js
+++ b/test/models/mobilenetv2_nhwc.js
@@ -151,7 +151,7 @@ describe('test mobilenetv2 nhwc', function() {
     const expected =
         await utils.createTypedArrayFromNpy(new URL(expectedFile, url));
     utils.checkValue(
-        outputs.softmax, expected, new utils.AccuracyCriterion(1e-5, 1e-3));
+        outputs.softmax, expected, utils.modelFp32AccuracyCriteria);
   }
 
   it('test_data_set_0', async function() {

--- a/test/models/squeezenet1.0_nhwc.js
+++ b/test/models/squeezenet1.0_nhwc.js
@@ -97,7 +97,7 @@ describe('test squeezenet1.0 nhwc', function() {
     const expected =
         await utils.createTypedArrayFromNpy(new URL(expectedFile, url));
     utils.checkValue(
-        outputs.softmax, expected, utils.ctsFp32RestrictAccuracyCriteria);
+        outputs.softmax, expected, utils.modelFp32AccuracyCriteria);
   }
 
   it('test_data_set_0', async function() {

--- a/test/models/squeezenet1.1_nchw.js
+++ b/test/models/squeezenet1.1_nchw.js
@@ -88,10 +88,7 @@ describe('test squeezenet1.1 nchw', function() {
     const expected =
         await utils.createTypedArrayFromNpy(new URL(expectedFile, url));
     utils.checkValue(
-        outputs.reshape0, expected,
-        // refer to onnx
-        // https://github.com/onnx/onnx/blob/master/onnx/backend/test/case/model/__init__.py#L58
-        new utils.AccuracyCriterion(1e-7, 1e-3));
+        outputs.reshape0, expected, utils.modelFp32AccuracyCriteria);
   }
 
   it('test_data_set_0', async function() {

--- a/test/utils.js
+++ b/test/utils.js
@@ -20,6 +20,12 @@ export const ctsFp32RestrictAccuracyCriteria =
 export const ctsFp32RelaxedAccuracyCriteria =
     new AccuracyCriterion(5.0 * 0.0009765625, 5.0 * 0.0009765625);
 
+// Refer to onnx/models
+//   https://github.com/onnx/models/blob/master/workflow_scripts/ort_test_dir_utils.py#L239
+// See details of modelFp32AccuracyCriteria setting:
+//   https://github.com/webmachinelearning/webnn-polyfill/issues/55
+export const modelFp32AccuracyCriteria = new AccuracyCriterion(1e-3, 1e-3);
+
 export function almostEqual(a, b, criteria) {
   const delta = Math.abs(a - b);
   if (delta <= criteria.atol + criteria.rtol * Math.abs(b)) {


### PR DESCRIPTION
Fixed #55. Now all 15 model tests with this updated criteria (atol=1e-3, rtol=1e-3) passed.
@huningxin PTAL, thanks.