### PR TITLE
Skip the test case for ML when it runs on Node.js

### DIFF
--- a/test/api/context.js
+++ b/test/api/context.js
@@ -3,8 +3,13 @@
 const expect = chai.expect;
 
 describe('test MLContext', function() {
-  it('navigator.ml should be a ML', () => {
-    expect(navigator.ml).to.be.an.instanceof(ML);
+  it('navigator.ml should be a ML', function CheckML() {
+    if (typeof window !== 'undefined') {
+      expect(navigator.ml).to.be.an.instanceof(ML);
+    } else {
+      // This case does not need to be tested on Node.js
+      this.skip();
+    }
   });
 
   it('ml.createContext should be a function', () => {


### PR DESCRIPTION
Skip the test case for ML when it runs on Node.js so that the error will be skipped for webnn-native. It is reasonable because the `navigator` does not exist in Node.js. The related issue is [Webnn-native #610](https://github.com/otcshare/webnn-native/issues/610).