### PR TITLE
Updated some tests purpose.

### DIFF
--- a/test/api/graph_builder.js
+++ b/test/api/graph_builder.js
@@ -39,10 +39,11 @@ describe('test MLGraphBuilder', function() {
     })).to.be.an.instanceof(MLOperand);
   });
 
-  it('builder.input should accept scalar operand descriptor', () => {
-    expect(builder.input('x', {type: 'float32', dimensions: []}))
-        .to.be.an.instanceof(MLOperand);
-  });
+  it('builder.input should accept scalar operand descriptor dimensions []',
+      () => {
+        expect(builder.input('x', {type: 'float32', dimensions: []}))
+            .to.be.an.instanceof(MLOperand);
+      });
 
   it('builder.input should throw for invalid name parameter', () => {
     expect(() => builder.input(1, desc)).to.throw(Error);
@@ -114,11 +115,12 @@ describe('test MLGraphBuilder', function() {
         .to.be.an.instanceof(MLOperand);
   });
 
-  it('builder.constant should accept scalar operand descriptor', () => {
-    const buffer = new Float32Array(1);
-    expect(builder.constant({type: 'float32', dimensions: []}, buffer))
-        .to.be.an.instanceof(MLOperand);
-  });
+  it('builder.constant should accept scalar operand descriptor dimensions []',
+      () => {
+        const buffer = new Float32Array(1);
+        expect(builder.constant({type: 'float32', dimensions: []}, buffer))
+            .to.be.an.instanceof(MLOperand);
+      });
 
   it('builder.constant should throw for invalid desc parameter', () => {
     const buffer = new Float32Array(4);

--- a/test/ops/pow.js
+++ b/test/ops/pow.js
@@ -65,7 +65,7 @@ describe('test pow', function() {
     utils.checkValue(outputs.z, [1., 32., 729.]);
   });
 
-  it('pow broadcast scalar', async function() {
+  it('pow broadcast with 1d of [3] and 1d of [1]', async function() {
     const builder = new MLGraphBuilder(context);
     const x = builder.input('x', {type: 'float32', dimensions: [3]});
     const y = builder.constant(
@@ -78,7 +78,7 @@ describe('test pow', function() {
     utils.checkValue(outputs.z, [1., 4., 9.]);
   });
 
-  it('pow broadcast scalar', async function() {
+  it('pow broadcast with 2d of [2, 3] and 1d of [3]', async function() {
     const builder = new MLGraphBuilder(context);
     const x = builder.input('x', {type: 'float32', dimensions: [2, 3]});
     const y = builder.constant(

--- a/test/ops/reshape.js
+++ b/test/ops/reshape.js
@@ -43,11 +43,11 @@ describe('test reshape', function() {
     testReshape([2, 3, 4], [24]);
   });
 
-  it('reshape negative_dim', function() {
+  it('reshape [2, 3, 4] to negative_dim [2, -1, 2]', function() {
     testReshape([2, 3, 4], [2, -1, 2], [2, 6, 2]);
   });
 
-  it('reshape negative_dim', function() {
+  it('reshape [2, 3, 4] to negative_dim [-1, 2, 3, 4]', function() {
     testReshape([2, 3, 4], [-1, 2, 3, 4], [1, 2, 3, 4]);
   });
 });


### PR DESCRIPTION
Hi @huningxin, current there're some tests with same purpose which couldn't be distinguished, likes :
```js
  // https://github.com/webmachinelearning/webnn-polyfill/blob/master/test/api/graph_builder.js#L36
  it('builder.input should accept scalar operand descriptor', () => {
    expect(builder.input('x', {
      type: 'float32',
    })).to.be.an.instanceof(MLOperand);
  });

  it('builder.input should accept scalar operand descriptor', () => {
    expect(builder.input('x', {type: 'float32', dimensions: []}))
        .to.be.an.instanceof(MLOperand);
  });
```

This PR is to update those tests purpose, PTAL, thanks. 