### PR TITLE
Add converted NNAPI CTS tests for reduceMax / reduceMin / reduceProduct / reduceSum ops.

### DIFF
--- a/test/cts/from_nnapi/README.md
+++ b/test/cts/from_nnapi/README.md
@@ -5,55 +5,51 @@ This [test_generator](./test_generator) tool is for converting existed native
 [NNAPI CTS](https://android.googlesource.com/platform/frameworks/ml/+/refs/tags/android-cts-10.0_r5/nn/runtime/test/specs/) of V1_0, V1_1 and V1_2 versions to these tests for WebNN API.
 
 ### NNAPI Operations being map to WebNN API Operations Tables
-* Part I 
 
 The `test_generator` tool has supported to convert those tests of following
-NNAPI operations to the tests for such WebNN API operations of first wave.
+NNAPI operations to the tests for such WebNN API operations.
 
-| NNAPI                         | WebNN API (first wave ops)    |
-|:------------------------------|:------------------------------|
-| RELU1                         | clamp                         |
-| RELU6                         | clamp                         |
-| CONCATENATION                 | concat                        |
-| ADD                           | add [+ relu/clamp]            |
-| SUB                           | sub [+ relu/clamp]            |
-| MUL                           | mul [+ relu/clamp]            |
-| DIV                           | div [+ relu/clamp]            |
-| MAXIMUM                       | max                           |
-| MINIMUM                       | min                           |
-| EXP                           | exp                           |
-| LOGISTIC                      | sigmoid                       |
-| SQRT                          | pow                           |
-| TANH                          | tanh                          |
-| FULLY_CONNECTED               | matmul [+ add+ relu/clamp]    |
-| AVERAGE_POOL_2D               | averagePool2d [+ relu/clamp]  |
-| MAX_POOL_2D                   | maxPool2d  [+ relu/clamp]     |
-| CONV_2D                       | conv2d [+ add + relu/clamp]   |
-| DEPTHWISE_CONV_2D             | conv2d [+ add + relu/clamp]   |
-| RELU                          | relu                          |
-| RESHAPE                       | reshape                       |
-| SLICE                         | slice                         |
-| SOFTMAX                       | softmax                       |
-| SPLIT                         | split                         |
-| SQUEEZE                       | squeeze                       |
-| TRANSPOSE                     | transpose                     |
-| PAD                           | pad                           |
-| PAD_V2                        | pad                           |
-| POW                           | pow                           |
-
-* Part II
-
-And there're these following NNAPI operations which could be map to others
-WebNN API operations of next waves.
-
-| NNAPI                         | WebNN API (next waves ops)     |
-|:------------------------------|:------------------------------|
-| ABS                           | abs                           |
-| FLOOR                         | floor                         |
-| LOG                           | log                           |
-| NEG                           | neg                           |
-| SIN                           | sin                           |
-| L2_POOL_2D                    | l2Pool2d  [+ relu/clamp]      |
+| NNAPI                         | WebNN API                            |
+|:------------------------------|:-------------------------------------|
+| RELU1                         | clamp                                |
+| RELU6                         | clamp                                |
+| CONCATENATION                 | concat                               |
+| CONV_2D                       | conv2d/conv2d [+ add + relu/clamp]   |
+| DEPTHWISE_CONV_2D             | conv2d/conv2d [+ add + relu/clamp]   |
+| ADD                           | add [+ relu/clamp]                   |
+| SUB                           | sub [+ relu/clamp]                   |
+| MUL                           | mul [+ relu/clamp]                   |
+| DIV                           | div [+ relu/clamp]                   |
+| MAXIMUM                       | max                                  |
+| MINIMUM                       | min                                  |
+| POW                           | pow                                  |
+| SQRT                          | pow                                  |
+| ABS                           | abs                                  |
+| EXP                           | exp                                  |
+| FLOOR                         | floor                                |
+| LOG                           | log                                  |
+| NEG                           | neg                                  |
+| SIN                           | sin                                  |
+| INSTANCE_NORMALIZATION        | instanceNormalization                |
+| FULLY_CONNECTED               | matmul [+ add+ relu/clamp]           |
+| PAD                           | pad                                  |
+| PAD_V2                        | pad                                  |
+| AVERAGE_POOL_2D               | averagePool2d [+ relu/clamp]         |
+| L2_POOL_2D                    | l2Pool2d  [+ relu/clamp]             |
+| MAX_POOL_2D                   | maxPool2d  [+ relu/clamp]            |
+| REDUCE_MAX                    | reduceMax                            |
+| REDUCE_MIN                    | reduceMin                            |
+| REDUCE_PROD                   | reduceProduct                        |
+| REDUCE_SUM                    | reduceSum                            |
+| RELU                          | relu                                 |
+| RESHAPE                       | reshape                              |
+| LOGISTIC                      | sigmoid                              |
+| SLICE                         | slice                                |
+| SOFTMAX                       | softmax                              |
+| SPLIT                         | split                                |
+| SQUEEZE                       | squeeze                              |
+| TANH                          | tanh                                 |
+| TRANSPOSE                     | transpose                            |
 
 * Note: 
 

--- a/test/cts/from_nnapi/test_generator/src/mapping_dict.py
+++ b/test/cts/from_nnapi/test_generator/src/mapping_dict.py
@@ -700,6 +700,94 @@ MappingDict = {
             }
         ]
     },
+    'REDUCE_MAX': {
+        'webnnOperation': 'reduceMax',
+        'insList': [
+            {
+                'name': 'input0',
+                'mappingParamIndex': 0,
+                'mappingRuleType': 0
+            },
+            {
+                'name': 'input1',
+                'mappingParamIndex': 1,
+                'optionsDictKey': 'axes',
+                'mappingRuleType': 3
+            },
+            {
+                'name': 'input2',
+                'mappingParamIndex': 1,
+                'optionsDictKey': 'keepDimensions',
+                'mappingRuleType': 1
+            },
+        ]
+    },
+    'REDUCE_MIN': {
+        'webnnOperation': 'reduceMin',
+        'insList': [
+            {
+                'name': 'input0',
+                'mappingParamIndex': 0,
+                'mappingRuleType': 0
+            },
+            {
+                'name': 'input1',
+                'mappingParamIndex': 1,
+                'optionsDictKey': 'axes',
+                'mappingRuleType': 3
+            },
+            {
+                'name': 'input2',
+                'mappingParamIndex': 1,
+                'optionsDictKey': 'keepDimensions',
+                'mappingRuleType': 1
+            },
+        ]
+    },
+    'REDUCE_PROD': {
+        'webnnOperation': 'reduceProduct',
+        'insList': [
+            {
+                'name': 'input0',
+                'mappingParamIndex': 0,
+                'mappingRuleType': 0
+            },
+            {
+                'name': 'input1',
+                'mappingParamIndex': 1,
+                'optionsDictKey': 'axes',
+                'mappingRuleType': 3
+            },
+            {
+                'name': 'input2',
+                'mappingParamIndex': 1,
+                'optionsDictKey': 'keepDimensions',
+                'mappingRuleType': 1
+            },
+        ]
+    },
+    'REDUCE_SUM': {
+        'webnnOperation': 'reduceSum',
+        'insList': [
+            {
+                'name': 'input0',
+                'mappingParamIndex': 0,
+                'mappingRuleType': 0
+            },
+            {
+                'name': 'input1',
+                'mappingParamIndex': 1,
+                'optionsDictKey': 'axes',
+                'mappingRuleType': 3
+            },
+            {
+                'name': 'input2',
+                'mappingParamIndex': 1,
+                'optionsDictKey': 'keepDimensions',
+                'mappingRuleType': 1
+            },
+        ]
+    },
     'RELU': {
         'webnnOperation': 'relu',
         'insList': [

--- a/test/cts/from_nnapi/tests/V1_2/test_reduceMax_converted_from_reduce_max.js
+++ b/test/cts/from_nnapi/tests/V1_2/test_reduceMax_converted_from_reduce_max.js
@@ -1,0 +1,98 @@
+'use strict';
+import * as utils from '../../../../utils.js';
+
+/* eslint-disable max-len */
+describe('CTS converted from NNAPI CTS', function() {
+  const context = navigator.ml.createContext();
+
+  it('test reduceMax converted from reduce_max test', function() {
+    // Converted test case (from: V1_2/reduce_max.mod.py)
+    const builder = new MLGraphBuilder(context);
+    const input0 = builder.input('input0', {type: 'float32', dimensions: [3, 2]});
+    const input0Data = new Float32Array([-1, -2, 3, 4, 5, -6]);
+    const param = [-1];
+    const param1 = false;
+    const expected = [-1, 4, 5];
+    const output0 = builder.reduceMax(input0, {'axes': param, 'keepDimensions': param1});
+    const graph = builder.build({output0});
+    const outputs = {output0: new Float32Array(utils.sizeOfShape([3]))};
+    graph.compute({'input0': input0Data}, outputs);
+    utils.checkValue(outputs.output0, expected, utils.ctsFp32RestrictAccuracyCriteria);
+  });
+
+  it('test reduceMax converted from reduce_max_relaxed test', function() {
+    // Converted test case (from: V1_2/reduce_max.mod.py)
+    const builder = new MLGraphBuilder(context);
+    const input0 = builder.input('input0', {type: 'float32', dimensions: [3, 2]});
+    const input0Data = new Float32Array([-1, -2, 3, 4, 5, -6]);
+    const param = [-1];
+    const param1 = false;
+    const expected = [-1, 4, 5];
+    const output0 = builder.reduceMax(input0, {'axes': param, 'keepDimensions': param1});
+    const graph = builder.build({output0});
+    const outputs = {output0: new Float32Array(utils.sizeOfShape([3]))};
+    graph.compute({'input0': input0Data}, outputs);
+    utils.checkValue(outputs.output0, expected, utils.ctsFp32RelaxedAccuracyCriteria);
+  });
+
+  it('test reduceMax converted from reduce_max_2 test', function() {
+    // Converted test case (from: V1_2/reduce_max.mod.py)
+    const builder = new MLGraphBuilder(context);
+    const input01 = builder.input('input01', {type: 'float32', dimensions: [1]});
+    const input01Data = new Float32Array([9.527]);
+    const param2 = [0];
+    const param3 = true;
+    const expected = [9.527];
+    const output01 = builder.reduceMax(input01, {'axes': param2, 'keepDimensions': param3});
+    const graph = builder.build({output01});
+    const outputs = {output01: new Float32Array(utils.sizeOfShape([1]))};
+    graph.compute({'input01': input01Data}, outputs);
+    utils.checkValue(outputs.output01, expected, utils.ctsFp32RestrictAccuracyCriteria);
+  });
+
+  it('test reduceMax converted from reduce_max_relaxed_2 test', function() {
+    // Converted test case (from: V1_2/reduce_max.mod.py)
+    const builder = new MLGraphBuilder(context);
+    const input01 = builder.input('input01', {type: 'float32', dimensions: [1]});
+    const input01Data = new Float32Array([9.527]);
+    const param2 = [0];
+    const param3 = true;
+    const expected = [9.527];
+    const output01 = builder.reduceMax(input01, {'axes': param2, 'keepDimensions': param3});
+    const graph = builder.build({output01});
+    const outputs = {output01: new Float32Array(utils.sizeOfShape([1]))};
+    graph.compute({'input01': input01Data}, outputs);
+    utils.checkValue(outputs.output01, expected, utils.ctsFp32RelaxedAccuracyCriteria);
+  });
+
+  it('test reduceMax converted from reduce_max_4 test', function() {
+    // Converted test case (from: V1_2/reduce_max.mod.py)
+    const builder = new MLGraphBuilder(context);
+    const input03 = builder.input('input03', {type: 'float32', dimensions: [4, 3, 2]});
+    const input03Data = new Float32Array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4]);
+    const param6 = [0, 2];
+    const param7 = true;
+    const expected = [2.0, 2.2, 2.4];
+    const output03 = builder.reduceMax(input03, {'axes': param6, 'keepDimensions': param7});
+    const graph = builder.build({output03});
+    const outputs = {output03: new Float32Array(utils.sizeOfShape([1, 3, 1]))};
+    graph.compute({'input03': input03Data}, outputs);
+    utils.checkValue(outputs.output03, expected, utils.ctsFp32RestrictAccuracyCriteria);
+  });
+
+  it('test reduceMax converted from reduce_max_relaxed_4 test', function() {
+    // Converted test case (from: V1_2/reduce_max.mod.py)
+    const builder = new MLGraphBuilder(context);
+    const input03 = builder.input('input03', {type: 'float32', dimensions: [4, 3, 2]});
+    const input03Data = new Float32Array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4]);
+    const param6 = [0, 2];
+    const param7 = true;
+    const expected = [2.0, 2.2, 2.4];
+    const output03 = builder.reduceMax(input03, {'axes': param6, 'keepDimensions': param7});
+    const graph = builder.build({output03});
+    const outputs = {output03: new Float32Array(utils.sizeOfShape([1, 3, 1]))};
+    graph.compute({'input03': input03Data}, outputs);
+    utils.checkValue(outputs.output03, expected, utils.ctsFp32RelaxedAccuracyCriteria);
+  });
+});
+/* eslint-disable max-len */

--- a/test/cts/from_nnapi/tests/V1_2/test_reduceMin_converted_from_reduce_min.js
+++ b/test/cts/from_nnapi/tests/V1_2/test_reduceMin_converted_from_reduce_min.js
@@ -1,0 +1,98 @@
+'use strict';
+import * as utils from '../../../../utils.js';
+
+/* eslint-disable max-len */
+describe('CTS converted from NNAPI CTS', function() {
+  const context = navigator.ml.createContext();
+
+  it('test reduceMin converted from reduce_min test', function() {
+    // Converted test case (from: V1_2/reduce_min.mod.py)
+    const builder = new MLGraphBuilder(context);
+    const input0 = builder.input('input0', {type: 'float32', dimensions: [3, 2]});
+    const input0Data = new Float32Array([-1, -2, 3, 4, 5, -6]);
+    const param = [-1];
+    const param1 = false;
+    const expected = [-2, 3, -6];
+    const output0 = builder.reduceMin(input0, {'axes': param, 'keepDimensions': param1});
+    const graph = builder.build({output0});
+    const outputs = {output0: new Float32Array(utils.sizeOfShape([3]))};
+    graph.compute({'input0': input0Data}, outputs);
+    utils.checkValue(outputs.output0, expected, utils.ctsFp32RestrictAccuracyCriteria);
+  });
+
+  it('test reduceMin converted from reduce_min_relaxed test', function() {
+    // Converted test case (from: V1_2/reduce_min.mod.py)
+    const builder = new MLGraphBuilder(context);
+    const input0 = builder.input('input0', {type: 'float32', dimensions: [3, 2]});
+    const input0Data = new Float32Array([-1, -2, 3, 4, 5, -6]);
+    const param = [-1];
+    const param1 = false;
+    const expected = [-2, 3, -6];
+    const output0 = builder.reduceMin(input0, {'axes': param, 'keepDimensions': param1});
+    const graph = builder.build({output0});
+    const outputs = {output0: new Float32Array(utils.sizeOfShape([3]))};
+    graph.compute({'input0': input0Data}, outputs);
+    utils.checkValue(outputs.output0, expected, utils.ctsFp32RelaxedAccuracyCriteria);
+  });
+
+  it('test reduceMin converted from reduce_min_2 test', function() {
+    // Converted test case (from: V1_2/reduce_min.mod.py)
+    const builder = new MLGraphBuilder(context);
+    const input01 = builder.input('input01', {type: 'float32', dimensions: [1]});
+    const input01Data = new Float32Array([9.527]);
+    const param2 = [0];
+    const param3 = true;
+    const expected = [9.527];
+    const output01 = builder.reduceMin(input01, {'axes': param2, 'keepDimensions': param3});
+    const graph = builder.build({output01});
+    const outputs = {output01: new Float32Array(utils.sizeOfShape([1]))};
+    graph.compute({'input01': input01Data}, outputs);
+    utils.checkValue(outputs.output01, expected, utils.ctsFp32RestrictAccuracyCriteria);
+  });
+
+  it('test reduceMin converted from reduce_min_relaxed_2 test', function() {
+    // Converted test case (from: V1_2/reduce_min.mod.py)
+    const builder = new MLGraphBuilder(context);
+    const input01 = builder.input('input01', {type: 'float32', dimensions: [1]});
+    const input01Data = new Float32Array([9.527]);
+    const param2 = [0];
+    const param3 = true;
+    const expected = [9.527];
+    const output01 = builder.reduceMin(input01, {'axes': param2, 'keepDimensions': param3});
+    const graph = builder.build({output01});
+    const outputs = {output01: new Float32Array(utils.sizeOfShape([1]))};
+    graph.compute({'input01': input01Data}, outputs);
+    utils.checkValue(outputs.output01, expected, utils.ctsFp32RelaxedAccuracyCriteria);
+  });
+
+  it('test reduceMin converted from reduce_min_4 test', function() {
+    // Converted test case (from: V1_2/reduce_min.mod.py)
+    const builder = new MLGraphBuilder(context);
+    const input03 = builder.input('input03', {type: 'float32', dimensions: [4, 3, 2]});
+    const input03Data = new Float32Array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4]);
+    const param6 = [0, 2];
+    const param7 = true;
+    const expected = [0.1, 0.3, 0.5];
+    const output03 = builder.reduceMin(input03, {'axes': param6, 'keepDimensions': param7});
+    const graph = builder.build({output03});
+    const outputs = {output03: new Float32Array(utils.sizeOfShape([1, 3, 1]))};
+    graph.compute({'input03': input03Data}, outputs);
+    utils.checkValue(outputs.output03, expected, utils.ctsFp32RestrictAccuracyCriteria);
+  });
+
+  it('test reduceMin converted from reduce_min_relaxed_4 test', function() {
+    // Converted test case (from: V1_2/reduce_min.mod.py)
+    const builder = new MLGraphBuilder(context);
+    const input03 = builder.input('input03', {type: 'float32', dimensions: [4, 3, 2]});
+    const input03Data = new Float32Array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4]);
+    const param6 = [0, 2];
+    const param7 = true;
+    const expected = [0.1, 0.3, 0.5];
+    const output03 = builder.reduceMin(input03, {'axes': param6, 'keepDimensions': param7});
+    const graph = builder.build({output03});
+    const outputs = {output03: new Float32Array(utils.sizeOfShape([1, 3, 1]))};
+    graph.compute({'input03': input03Data}, outputs);
+    utils.checkValue(outputs.output03, expected, utils.ctsFp32RelaxedAccuracyCriteria);
+  });
+});
+/* eslint-disable max-len */

--- a/test/cts/from_nnapi/tests/V1_2/test_reduceProduct_converted_from_reduce_prod.js
+++ b/test/cts/from_nnapi/tests/V1_2/test_reduceProduct_converted_from_reduce_prod.js
@@ -1,0 +1,98 @@
+'use strict';
+import * as utils from '../../../../utils.js';
+
+/* eslint-disable max-len */
+describe('CTS converted from NNAPI CTS', function() {
+  const context = navigator.ml.createContext();
+
+  it('test reduceProduct converted from reduce_prod test', function() {
+    // Converted test case (from: V1_2/reduce_prod.mod.py)
+    const builder = new MLGraphBuilder(context);
+    const input0 = builder.input('input0', {type: 'float32', dimensions: [3, 2]});
+    const input0Data = new Float32Array([-1, -2, 3, 4, 5, -6]);
+    const param = [-1];
+    const param1 = false;
+    const expected = [2, 12, -30];
+    const output0 = builder.reduceProduct(input0, {'axes': param, 'keepDimensions': param1});
+    const graph = builder.build({output0});
+    const outputs = {output0: new Float32Array(utils.sizeOfShape([3]))};
+    graph.compute({'input0': input0Data}, outputs);
+    utils.checkValue(outputs.output0, expected, utils.ctsFp32RestrictAccuracyCriteria);
+  });
+
+  it('test reduceProduct converted from reduce_prod_relaxed test', function() {
+    // Converted test case (from: V1_2/reduce_prod.mod.py)
+    const builder = new MLGraphBuilder(context);
+    const input0 = builder.input('input0', {type: 'float32', dimensions: [3, 2]});
+    const input0Data = new Float32Array([-1, -2, 3, 4, 5, -6]);
+    const param = [-1];
+    const param1 = false;
+    const expected = [2, 12, -30];
+    const output0 = builder.reduceProduct(input0, {'axes': param, 'keepDimensions': param1});
+    const graph = builder.build({output0});
+    const outputs = {output0: new Float32Array(utils.sizeOfShape([3]))};
+    graph.compute({'input0': input0Data}, outputs);
+    utils.checkValue(outputs.output0, expected, utils.ctsFp32RelaxedAccuracyCriteria);
+  });
+
+  it('test reduceProduct converted from reduce_prod_2 test', function() {
+    // Converted test case (from: V1_2/reduce_prod.mod.py)
+    const builder = new MLGraphBuilder(context);
+    const input01 = builder.input('input01', {type: 'float32', dimensions: [1]});
+    const input01Data = new Float32Array([9.527]);
+    const param2 = [0];
+    const param3 = true;
+    const expected = [9.527];
+    const output01 = builder.reduceProduct(input01, {'axes': param2, 'keepDimensions': param3});
+    const graph = builder.build({output01});
+    const outputs = {output01: new Float32Array(utils.sizeOfShape([1]))};
+    graph.compute({'input01': input01Data}, outputs);
+    utils.checkValue(outputs.output01, expected, utils.ctsFp32RestrictAccuracyCriteria);
+  });
+
+  it('test reduceProduct converted from reduce_prod_relaxed_2 test', function() {
+    // Converted test case (from: V1_2/reduce_prod.mod.py)
+    const builder = new MLGraphBuilder(context);
+    const input01 = builder.input('input01', {type: 'float32', dimensions: [1]});
+    const input01Data = new Float32Array([9.527]);
+    const param2 = [0];
+    const param3 = true;
+    const expected = [9.527];
+    const output01 = builder.reduceProduct(input01, {'axes': param2, 'keepDimensions': param3});
+    const graph = builder.build({output01});
+    const outputs = {output01: new Float32Array(utils.sizeOfShape([1]))};
+    graph.compute({'input01': input01Data}, outputs);
+    utils.checkValue(outputs.output01, expected, utils.ctsFp32RelaxedAccuracyCriteria);
+  });
+
+  it('test reduceProduct converted from reduce_prod_4 test', function() {
+    // Converted test case (from: V1_2/reduce_prod.mod.py)
+    const builder = new MLGraphBuilder(context);
+    const input03 = builder.input('input03', {type: 'float32', dimensions: [4, 3, 2]});
+    const input03Data = new Float32Array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4]);
+    const param6 = [0, 2];
+    const param7 = true;
+    const expected = [774.592, 1197.504, 668.89152];
+    const output03 = builder.reduceProduct(input03, {'axes': param6, 'keepDimensions': param7});
+    const graph = builder.build({output03});
+    const outputs = {output03: new Float32Array(utils.sizeOfShape([1, 3, 1]))};
+    graph.compute({'input03': input03Data}, outputs);
+    utils.checkValue(outputs.output03, expected, utils.ctsFp32RestrictAccuracyCriteria);
+  });
+
+  it('test reduceProduct converted from reduce_prod_relaxed_4 test', function() {
+    // Converted test case (from: V1_2/reduce_prod.mod.py)
+    const builder = new MLGraphBuilder(context);
+    const input03 = builder.input('input03', {type: 'float32', dimensions: [4, 3, 2]});
+    const input03Data = new Float32Array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4]);
+    const param6 = [0, 2];
+    const param7 = true;
+    const expected = [774.592, 1197.504, 668.89152];
+    const output03 = builder.reduceProduct(input03, {'axes': param6, 'keepDimensions': param7});
+    const graph = builder.build({output03});
+    const outputs = {output03: new Float32Array(utils.sizeOfShape([1, 3, 1]))};
+    graph.compute({'input03': input03Data}, outputs);
+    utils.checkValue(outputs.output03, expected, utils.ctsFp32RelaxedAccuracyCriteria);
+  });
+});
+/* eslint-disable max-len */

--- a/test/cts/from_nnapi/tests/V1_2/test_reduceSum_converted_from_reduce_sum.js
+++ b/test/cts/from_nnapi/tests/V1_2/test_reduceSum_converted_from_reduce_sum.js
@@ -1,0 +1,98 @@
+'use strict';
+import * as utils from '../../../../utils.js';
+
+/* eslint-disable max-len */
+describe('CTS converted from NNAPI CTS', function() {
+  const context = navigator.ml.createContext();
+
+  it('test reduceSum converted from reduce_sum test', function() {
+    // Converted test case (from: V1_2/reduce_sum.mod.py)
+    const builder = new MLGraphBuilder(context);
+    const input0 = builder.input('input0', {type: 'float32', dimensions: [3, 2]});
+    const input0Data = new Float32Array([-1, -2, 3, 4, 5, -6]);
+    const param = [-1];
+    const param1 = false;
+    const expected = [-3, 7, -1];
+    const output0 = builder.reduceSum(input0, {'axes': param, 'keepDimensions': param1});
+    const graph = builder.build({output0});
+    const outputs = {output0: new Float32Array(utils.sizeOfShape([3]))};
+    graph.compute({'input0': input0Data}, outputs);
+    utils.checkValue(outputs.output0, expected, utils.ctsFp32RestrictAccuracyCriteria);
+  });
+
+  it('test reduceSum converted from reduce_sum_relaxed test', function() {
+    // Converted test case (from: V1_2/reduce_sum.mod.py)
+    const builder = new MLGraphBuilder(context);
+    const input0 = builder.input('input0', {type: 'float32', dimensions: [3, 2]});
+    const input0Data = new Float32Array([-1, -2, 3, 4, 5, -6]);
+    const param = [-1];
+    const param1 = false;
+    const expected = [-3, 7, -1];
+    const output0 = builder.reduceSum(input0, {'axes': param, 'keepDimensions': param1});
+    const graph = builder.build({output0});
+    const outputs = {output0: new Float32Array(utils.sizeOfShape([3]))};
+    graph.compute({'input0': input0Data}, outputs);
+    utils.checkValue(outputs.output0, expected, utils.ctsFp32RelaxedAccuracyCriteria);
+  });
+
+  it('test reduceSum converted from reduce_sum_2 test', function() {
+    // Converted test case (from: V1_2/reduce_sum.mod.py)
+    const builder = new MLGraphBuilder(context);
+    const input01 = builder.input('input01', {type: 'float32', dimensions: [1]});
+    const input01Data = new Float32Array([9.527]);
+    const param2 = [0];
+    const param3 = true;
+    const expected = [9.527];
+    const output01 = builder.reduceSum(input01, {'axes': param2, 'keepDimensions': param3});
+    const graph = builder.build({output01});
+    const outputs = {output01: new Float32Array(utils.sizeOfShape([1]))};
+    graph.compute({'input01': input01Data}, outputs);
+    utils.checkValue(outputs.output01, expected, utils.ctsFp32RestrictAccuracyCriteria);
+  });
+
+  it('test reduceSum converted from reduce_sum_relaxed_2 test', function() {
+    // Converted test case (from: V1_2/reduce_sum.mod.py)
+    const builder = new MLGraphBuilder(context);
+    const input01 = builder.input('input01', {type: 'float32', dimensions: [1]});
+    const input01Data = new Float32Array([9.527]);
+    const param2 = [0];
+    const param3 = true;
+    const expected = [9.527];
+    const output01 = builder.reduceSum(input01, {'axes': param2, 'keepDimensions': param3});
+    const graph = builder.build({output01});
+    const outputs = {output01: new Float32Array(utils.sizeOfShape([1]))};
+    graph.compute({'input01': input01Data}, outputs);
+    utils.checkValue(outputs.output01, expected, utils.ctsFp32RelaxedAccuracyCriteria);
+  });
+
+  it('test reduceSum converted from reduce_sum_4 test', function() {
+    // Converted test case (from: V1_2/reduce_sum.mod.py)
+    const builder = new MLGraphBuilder(context);
+    const input03 = builder.input('input03', {type: 'float32', dimensions: [4, 3, 2]});
+    const input03Data = new Float32Array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4]);
+    const param6 = [0, 2];
+    const param7 = true;
+    const expected = [8.4, 10.0, 11.6];
+    const output03 = builder.reduceSum(input03, {'axes': param6, 'keepDimensions': param7});
+    const graph = builder.build({output03});
+    const outputs = {output03: new Float32Array(utils.sizeOfShape([1, 3, 1]))};
+    graph.compute({'input03': input03Data}, outputs);
+    utils.checkValue(outputs.output03, expected, utils.ctsFp32RestrictAccuracyCriteria);
+  });
+
+  it('test reduceSum converted from reduce_sum_relaxed_4 test', function() {
+    // Converted test case (from: V1_2/reduce_sum.mod.py)
+    const builder = new MLGraphBuilder(context);
+    const input03 = builder.input('input03', {type: 'float32', dimensions: [4, 3, 2]});
+    const input03Data = new Float32Array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4]);
+    const param6 = [0, 2];
+    const param7 = true;
+    const expected = [8.4, 10.0, 11.6];
+    const output03 = builder.reduceSum(input03, {'axes': param6, 'keepDimensions': param7});
+    const graph = builder.build({output03});
+    const outputs = {output03: new Float32Array(utils.sizeOfShape([1, 3, 1]))};
+    graph.compute({'input03': input03Data}, outputs);
+    utils.checkValue(outputs.output03, expected, utils.ctsFp32RelaxedAccuracyCriteria);
+  });
+});
+/* eslint-disable max-len */


### PR DESCRIPTION
This PR is to add 24 converted reduce tests. 

Besides, I also updated previous [NNAPI to WebNN Op mapping table](https://docs.google.com/spreadsheets/d/18iALLiz8plA75KVvMB1PitU6FU6GKoZ8-DcDDZgmrA4/edit#gid=0) to align with latest WebNN API Spec.

@huningxin PTAL, thanks. 