### PR TITLE
Copy data when creating constant operand

### DIFF
--- a/src/nn/operand.ts
+++ b/src/nn/operand.ts
@@ -77,7 +77,7 @@ export class ConstantOperand extends MLOperand {
     const array = value as ArrayBufferView;
     utils.validateOperandDescriptor(desc);
     utils.validateTypedArray(array, desc.type, desc.dimensions);
-    return new ConstantOperand(desc, array, builder);
+    return new ConstantOperand(desc, array.slice(), builder);
   }
 
   private constructor(


### PR DESCRIPTION
This would fix the issue caused by the wasm heap resizing during
the graph building.

This implementation aligns with webnn-native node.js binding.

@BruceDai , PTAL. Thanks.