### PR TITLE
Use ULP based comparison.

### DIFF
--- a/.eslintrcforjs.js
+++ b/.eslintrcforjs.js
@@ -11,6 +11,7 @@ module.exports = {
     'MLGraph': 'readonly',
     'MLOperand': 'readonly',
     '_tfengine': 'readonly',
+    'BigInt': 'readonly',
     'BigInt64Array': 'readonly',
     'BigUint64Array': 'readonly',
     'fs': 'readonly',

--- a/test/utils.js
+++ b/test/utils.js
@@ -36,6 +36,22 @@ export function almostEqual(a, b, criteria) {
   }
 }
 
+function getBitwise(value) {
+  const buffer = new ArrayBuffer(4);
+  const view = new DataView(buffer);
+  view.setFloat32(0, value);
+  return view.getInt32(0);
+}
+
+export function compareUlp(a, b, nulp = 1, format = 'float32') {
+  assert(format === 'float32', `Format ${format} is not supported.`);
+  const aBitwise = getBitwise(a);
+  const bBitwise = getBitwise(b);
+  let distance = aBitwise - bBitwise;
+  distance = distance > 0 ? distance : -distance;
+  return distance > nulp;
+}
+
 export function checkValue(
     output, expected, criteria = opFp32AccuracyCriteria) {
   assert.isTrue(output.length === expected.length);

--- a/test/utils.js
+++ b/test/utils.js
@@ -36,19 +36,21 @@ export function almostEqual(a, b, criteria) {
   }
 }
 
-function getBitwise(value) {
-  const buffer = new ArrayBuffer(4);
-  const view = new DataView(buffer);
-  view.setFloat32(0, value);
-  return view.getInt32(0);
+export function getBitwiseFloat32(value) {
+  const buffer = new ArrayBuffer(8);
+  const int64Array = new BigInt64Array(buffer);
+  int64Array[0] = value < 0 ? ~BigInt(0) : BigInt(0);
+  const f32Array = new Float32Array(buffer);
+  f32Array[0] = value;
+  return int64Array[0];
 }
 
-export function compareUlp(a, b, nulp = 1, format = 'float32') {
-  assert(format === 'float32', `Format ${format} is not supported.`);
-  const aBitwise = getBitwise(a);
-  const bBitwise = getBitwise(b);
+export function compareUlp(a, b, nulp = 1n, dataType = 'float32') {
+  assert(dataType === 'float32', `DataType ${dataType} is not supported.`);
+  const aBitwise = getBitwiseFloat32(a);
+  const bBitwise = getBitwiseFloat32(b);
   let distance = aBitwise - bBitwise;
-  distance = distance > 0 ? distance : -distance;
+  distance = distance >= 0 ? distance : -distance;
   return distance > nulp;
 }
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -36,19 +36,44 @@ export function almostEqual(a, b, criteria) {
   }
 }
 
-export function getBitwiseFloat32(value) {
+/**
+ * Get bitwise of the given value.
+ * @param {number} value
+ * @param {string} dataType A data type string, like "float32", "int8",
+ *     more data type strings, please see:
+ *     https://webmachinelearning.github.io/webnn/#enumdef-mloperandtype
+ * @return {number} A 64-bit signed integer.
+ */
+export function getBitwise(value, dataType) {
   const buffer = new ArrayBuffer(8);
   const int64Array = new BigInt64Array(buffer);
   int64Array[0] = value < 0 ? ~BigInt(0) : BigInt(0);
-  const f32Array = new Float32Array(buffer);
-  f32Array[0] = value;
+  let typedArray;
+  if (dataType === 'float32') {
+    typedArray = new Float32Array(buffer);
+  } else {
+    throw Error(`Data type ${dataType} is not supported.`);
+  }
+  typedArray[0] = value;
   return int64Array[0];
 }
 
+/**
+ * Compare the distance between a and b with given ULP distance.
+ * @param {number} a
+ * @param {number} b
+ * @param {number} nulp A BigInt value.
+ * @param {string} dataType A data type string, default "float32",
+ *     more data type strings, please see:
+ *     https://webmachinelearning.github.io/webnn/#enumdef-mloperandtype
+ * @return {Boolean} A boolean value:
+ *     true: The distance between a and b is greater than given ULP distance.
+ *     false: The distance between a and b is less than or equal to given ULP
+ *            distance.
+ */
 export function compareUlp(a, b, nulp = 1n, dataType = 'float32') {
-  assert(dataType === 'float32', `DataType ${dataType} is not supported.`);
-  const aBitwise = getBitwiseFloat32(a);
-  const bBitwise = getBitwiseFloat32(b);
+  const aBitwise = getBitwise(a, dataType);
+  const bBitwise = getBitwise(b, dataType);
   let distance = aBitwise - bBitwise;
   distance = distance >= 0 ? distance : -distance;
   return distance > nulp;


### PR DESCRIPTION
> ```c++
> int64_t GetBitwise(float value) {
>     int64_t bitwiseValue = (value < T(0)) ? ~int64_t(0) : 0; // Extend sign.
>     *std::launder(reinterpret_cast<T*>(&bitwiseValue)) = value;
>     return bitwiseValue;
> }
> 
> bool CompareUlp(float a, float b, uint64_t ulp) {
>     return static_cast<uint64_t>(abs(GetBitwise(a) - GetBitwise(b))) > ulp;
> }
> ```
> 

@huningxin I implemented JavaScript `compareUlp()` function to align Chai's comment on #2, PTAL, thanks.

