### PR TITLE
Fixed outputShape issue of convTranspose2d op by WebGL backend

### DIFF
--- a/src/nn/ops/conv_transpose2d.ts
+++ b/src/nn/ops/conv_transpose2d.ts
@@ -232,16 +232,15 @@ export class ConvTranspose2d extends SingleOutputOperation
     } else if (this.fusedActivation_ !== undefined) {
       utils.assert(false, `The ${this.fusedActivation_} is un supported.`);
     }
+    let expectedShape = outputShape.slice();
     if (this.inputLayout_ === MLInputOperandLayout.nchw) {
       // nhwc -> nchw
       output = tf.transpose(output, [0, 3, 1, 2]);
-      const outputChannel = outputShape[3];
-      outputShape[3] = outputShape[2];
-      outputShape[2] = outputShape[1];
-      outputShape[1] = outputChannel;
+      expectedShape =
+        [outputShape[0], outputShape[3], outputShape[1], outputShape[2]];
     }
     if (this.needCheckOutputShape_) {
-      utils.checkShape(output.shape, outputShape);
+      utils.checkShape(output.shape, expectedShape);
       this.needCheckOutputShape_ = false;
     }
     return output;


### PR DESCRIPTION
This PR is to fix #174.

WebNN-Polyfill WebGL backend is based on tf.js WebGL backend. When compiling graph by WebGL backend, [tf.js WebGL backend would run WebGL program and save binary cache if the cache didn't exist](https://github.com/tensorflow/tfjs/blob/9581a314beb5f3c57071955ae2ad265ec851010c/tfjs-backend-webgl/src/backend_webgl.ts#L941), we happened to modify that `outputShape` previously for output of NCHW layout, then relevant saved binary cache was changed. This fixing is to protect saved cache from changes. 

@huningxin @Honry PTAL, thanks.
