### PR TITLE
Expose wasm interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,34 @@ WebNN Polyfill requires setting backend to enable TensorFlow.js.
     await tf.ready();
 ```
 
+* When running in browsers with WASM backend.
+
+```js
+    const backend = 'wasm';
+    const context = await navigator.ml.createContext();
+    const wasm = context.wasm;
+
+    // 1- Enforce use Wasm SIMD binary
+    wasm.setWasmPath(`${path}/tfjs-backend-wasm-simd.wasm`);
+
+    // 2- Use Wasm SIMD + Threads bianry if supported both SIMD and Threads
+    // 2.1- Configure by the path to the directory where the WASM binaries are located
+    //        wasm.setWasmPaths(`https://unpkg.com/@tensorflow/tfjs-backend-wasm@${tf.version_core}/dist/`);
+    //      or mapping from names of WASM binaries to custom full paths specifying the locations of those binaries
+    //        wasm.setWasmPaths({
+    //          'tfjs-backend-wasm.wasm': 'renamed.wasm',
+    //          'tfjs-backend-wasm-simd.wasm': 'renamed-simd.wasm',
+    //          'tfjs-backend-wasm-threaded-simd.wasm': 'renamed-threaded-simd.wasm'
+    //        });
+    wasm.setWasmPaths(${prefixOrFileMap}); 
+    // 2.2- Configure threads number manually, or it will use the number of logical CPU cores as the threads count by default
+    wasm.setThreadsCount(n); // n can be 1, 2, ...
+
+    const tf = context.tf;
+    await tf.setBackend(backend);
+    await tf.ready();
+```
+
 Please refer to the [`setPolyfillBackend()`](https://github.com/webmachinelearning/webnn-polyfill/search?q=setPolyfillBackend) usage in tests for concrete examples on how to best implement backend switching for your project.
 
 ### Samples

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webmachinelearning/webnn-polyfill",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "WebNN API polyfill",
   "main": "dist/webnn-polyfill.js",
   "jsdelivr": "dist/webnn-polyfill.js",

--- a/src/nn/context.ts
+++ b/src/nn/context.ts
@@ -103,11 +103,15 @@ export class MLContext {
   }
 
   /** @internal */
-  // Expose tf.js for backend debugging.
+  // Expose tf interfance for setting backend.
   get tf(): unknown {
-    // Set directory of wasm binaries for 'wasm' backend
-    wasm.setWasmPaths(`https://unpkg.com/@tensorflow/tfjs-backend-wasm@${
-        tf.version_core}/dist/`);
     return tf;
+  }
+
+  /** @internal */
+  // Expose wasm interface for supporting configure threads for wasm backend.
+  //     wasm.setThreadsCount(n)
+  get wasm(): unknown {
+    return wasm;
   }
 }

--- a/test/utils.js
+++ b/test/utils.js
@@ -199,6 +199,10 @@ async function readyPolyfillBackend(context, backend) {
         console.warn(`webnn-polyfill doesn't support ${backend} backend.`);
       }
     } else {
+      if (backend === 'wasm') {
+        const wasm = context.wasm;
+        wasm.setWasmPaths(`https://unpkg.com/@tensorflow/tfjs-backend-wasm@${tf.version_core}/dist/`);
+      }
       if (!(await tf.setBackend(backend))) {
         console.error(`Failed to set tf.js backend ${backend}.`);
       }


### PR DESCRIPTION
Current WebNN-Polyfill auto select WASM backend depending on environment's supports of TensorFlow Wasm backend, see below codes

```js
// In @tensorflow/tfjs-backend-wasm/dist/backend_wasm.js
/**
 * Initializes the wasm module and creates the js <--> wasm bridge.
 */
 export async function init() {
    const [simdSupported, threadsSupported] = await Promise.all([
        env().getAsync('WASM_HAS_SIMD_SUPPORT'),
        env().getAsync('WASM_HAS_MULTITHREAD_SUPPORT')
    ]);
    return new Promise((resolve, reject) => {
        const factoryConfig = {};
        ... ...
        factoryConfig.locateFile = (path, prefix) => {
            ... ...
            if (path.endsWith('.wasm')) {
                return getPathToWasmBinary(simdSupported, threadsSupported, wasmPathPrefix != null ? wasmPathPrefix : prefix);
            }
            return prefix + path;
        };
   ... ...
 }

/**
 * Returns the path of the WASM binary.
 * @param simdSupported whether SIMD is supported
 * @param threadsSupported whether multithreading is supported
 * @param wasmModuleFolder the directory containing the WASM binaries.
 */
function getPathToWasmBinary(simdSupported, threadsSupported, wasmModuleFolder) {
    ... ...
    let path = 'tfjs-backend-wasm.wasm';
    if (simdSupported && threadsSupported) {
        path = 'tfjs-backend-wasm-threaded-simd.wasm';
    }
    else if (simdSupported) {
        path = 'tfjs-backend-wasm-simd.wasm';
    }
    ... ....
    return wasmModuleFolder + path;
}
```

This PR is to expose **wasm** interface for user conveniently configuring threads for WASM backend if environment supported multi-threads, likes

```js
  const wasm = navigator.ml.createContext().wasm;
  // Here to configure threads number
  wasm.setThreadsCount(n);

  const tf = navigator.ml.createContext().tf;
  await tf.setBackend('wasm')
``` 

@huningxin @Honry PTAL, thanks.