### PR TITLE
Add source map support for stack traces in Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "lint": "npm run lint-ts && npm run lint-js",
     "fix-lint": "npm run lint-ts -- --fix && npm run lint-js -- --fix",
     "format": "clang-format --glob=\"{{src,test}/**/*.ts,{src,test}/**/*.js}\" --style=file -i",
-    "test": "cross-env NODE_ENV=test mocha --require ./node_setup.js --exit test/*/*.js --exclude test/ops/relu_sw.js test/cts/from_nnapi/tests/cts.js ./test/models/**/*.js",
-    "test-cts": "cross-env NODE_ENV=test mocha --require ./node_setup.js --exit test/cts/from_nnapi/tests/cts.js",
-    "test-models": "cross-env NODE_ENV=test mocha --require ./node_setup.js --exit ./test/models/**/*.js",
-    "test-ops": "cross-env NODE_ENV=test mocha --require ./node_setup.js --exit test/ops/*.js --exclude test/ops/relu_sw.js"
+    "test": "cross-env NODE_ENV=test mocha --require source-map-support/register --require ./node_setup.js --exit test/*/*.js --exclude test/ops/relu_sw.js test/cts/from_nnapi/tests/cts.js ./test/models/**/*.js",
+    "test-cts": "cross-env NODE_ENV=test mocha --require source-map-support/register --require ./node_setup.js --exit test/cts/from_nnapi/tests/cts.js",
+    "test-models": "cross-env NODE_ENV=test mocha --require source-map-support/register --require ./node_setup.js --exit ./test/models/**/*.js",
+    "test-ops": "cross-env NODE_ENV=test mocha --require source-map-support/register --require ./node_setup.js --exit test/ops/*.js --exclude test/ops/relu_sw.js"
   },
   "repository": {
     "type": "git",
@@ -70,6 +70,7 @@
     "http-server": "^14.1.1",
     "mocha": "^10.2.0",
     "portfinder": "^1.0.28",
+    "source-map-support": "^0.5.21",
     "terser-webpack-plugin": "^4.2.3",
     "ts-loader": "^8.2.0",
     "typedoc": "^0.23.24",


### PR DESCRIPTION
When running the tests in Node, since the library is compiled into a single file using Webpack, the source-map-support package is required to get readable stack traces.